### PR TITLE
fix: replace broken youtube-transcript and add caching workaround

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@craco/craco": "^7.1.0",
+    "@danielxceron/youtube-transcript": "^1.2.3",
     "@google/generative-ai": "^0.21.0",
     "@radix-ui/react-avatar": "^1.1.1",
     "@radix-ui/react-dialog": "^1.1.2",
@@ -31,8 +32,7 @@
     "tailwind-merge": "^2.5.4",
     "tailwindcss-animate": "^1.0.7",
     "web-vitals": "^2.1.4",
-    "Youtube-Study-Kit": "file:",
-    "youtube-transcript": "^1.2.1"
+    "Youtube-Study-Kit": "file:"
   },
   "scripts": {
     "start": "craco start",

--- a/src/lib/getSubtitles.js
+++ b/src/lib/getSubtitles.js
@@ -1,14 +1,58 @@
-import { YoutubeTranscript } from 'youtube-transcript';
-export async function getSubTitles(videoId) {
+/* global chrome */
+import { YoutubeTranscript } from "@danielxceron/youtube-transcript";
+
+const CACHE_TTL = 24 * 60 * 60 * 1000; // 24h
+export async function getSubTitles(videoId, opts = {}) {
+  const { forceRefresh = false } = opts;
+  const key = `subs_${videoId}`;
+
+  let cached = null;
+  if (chrome?.storage?.local) {
     try {
-        const transcript = await YoutubeTranscript.fetchTranscript(videoId);
-        let res = "";
-        transcript.forEach(ele => {
-            res += ele.text+" ";
-        });
-        return { text: JSON.stringify(res), subtitles: transcript };
-    } catch (error) {
-        console.error('Error fetching captions:', error); // Log the full error
-        throw new Error('Captions cannot be generated for this video.');
+      const { userData = {} } = await chrome.storage.local.get("userData");
+      cached = userData?.[videoId]?.[key];
+
+      if (cached && !forceRefresh && Date.now() - cached.ts < CACHE_TTL) {
+        // Fresh cache
+        return cached.data;
+      }
+    } catch (err) {
+      console.warn("Failed to read from local cache:", err);
     }
+  }
+
+  // Fetch a fresh transcript
+  try {
+    const transcript = await YoutubeTranscript.fetchTranscript(videoId);
+    let res = "";
+    transcript.forEach((ele) => {
+      res += ele.text + " ";
+    });
+
+    const data = { text: JSON.stringify(res), subtitles: transcript };
+    try {
+      const { userData = {} } = await chrome?.storage?.local?.get("userData");
+      if (userData[videoId] && typeof userData[videoId] === "object") {
+        userData[videoId][key] = { ts: Date.now(), data };
+        await chrome?.storage?.local?.set({ userData });
+      } else {
+        console.info(
+          `Could not store transcript, userData[${videoId}] does not exist`
+        );
+      }
+    } catch {
+      /* ignore if storage is unavailable */
+    }
+    return data;
+  } catch (error) {
+    console.error("Error fetching captions:", error); // Log the full error
+
+    // Fallback to cached (stale) data if available.
+    if (cached) {
+      console.warn("Using stale transcript due to fetch failure");
+      return cached.data;
+    }
+
+    throw new Error("Captions cannot be generated for this video.");
+  }
 }


### PR DESCRIPTION
This PR fixes the subtitle-fetching failure by replacing the broken youtube-transcript package. 

Since the Innertube API still fails when called from a Chrome extension, likely due to origin-based access restrictions. A simple caching strategy has been introduced to work around the fetch failure and avoid repeated API calls in the meantime. 