### PR TITLE
Bind model state at ChatSearch

### DIFF
--- a/src/components/ChatComponents/ChatSearch.jsx
+++ b/src/components/ChatComponents/ChatSearch.jsx
@@ -98,7 +98,7 @@ export default function ChatSearch({ messages, setMessages, timestampedSubtitles
             />
             <div className='text-[#ffffffe0] flex justify-between'>
                 <div>
-                    <Select onValueChange={(val) => setModel(val)} defaultValue={model}>
+                    <Select onValueChange={(val) => setModel(val)} value={model}>
                         <SelectTrigger className="bg-transparent">
                             <SelectValue placeholder="gemini" />
                         </SelectTrigger>


### PR DESCRIPTION
This PR applies a small fix to the model state logic in ChatSearch to ensure correct behavior of the Select component. It resolves inconsistencies between the model chosen and the one displayed on the page, preventing potential user confusion.