### PR TITLE
Move generateKeywords Prompt API call to Chrome extension background

### DIFF
--- a/public/background.js
+++ b/public/background.js
@@ -9,8 +9,24 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       const guideURL = chrome.runtime.getURL(message.url);
       chrome.tabs.create({ url: guideURL });
       sendResponse({ success: true });
+      return;
+    }
+
+    if (message.type === "PROMPT_GEMINI") {
+      (async () => {
+        try {
+          const session = await LanguageModel.create({
+            initialPrompts: [{ role: "system", content: message.initialPrompts }],
+          });
+          const keywords = await session.prompt(message.prompt);
+          session.destroy();
+          sendResponse({ ok: true, keywords });
+        } catch (e) {
+          sendResponse({ ok: false, error: String(e) });
+        }
+      })();
+      return true;
     }
   });
-  
 
 chrome.runtime.setUninstallURL('https://youtube-study-kit.vercel.app/');


### PR DESCRIPTION
This PR moves the generateKeywords Chrome builtin Prompt API call from the page/UI context into the Chrome extension background service worker.

### Why
Background context allows Prompt API usage without asking users to toggle any chrome://flags.

### What changed
background.js: add PROMPT_GEMINI handler; perform LanguageModel.create → prompt → destroy and reply.

generateKeywordMap.js: replace direct window.LanguageModel usage with chrome.runtime.sendMessage
