### PR TITLE
Fix: preserve existing fields when updating `userData[videoId]`

### DIFF
--- a/src/updateContent.js
+++ b/src/updateContent.js
@@ -59,6 +59,7 @@ async function saveImage(videoId, imgUrl, imgText, ytLink, timestamp, videoHeadi
             updatedData = {
                 ...previousData,
                 [videoId]: {
+                    ...previousData[videoId],
                     heading: videoHeading,
                     data: sortedData,
                     updatedAt


### PR DESCRIPTION
This PR prevent previously stored fields (e.g., subtitle) from being overwritten during image saves.

**What changed:** In `saveImage`, spread the existing `userData[videoId]` before setting `heading`, `data`, and `updatedAt`.